### PR TITLE
feat: Implement three-tier model selection hierarchy

### DIFF
--- a/packages/core/securevibes/agents/__init__.py
+++ b/packages/core/securevibes/agents/__init__.py
@@ -1,7 +1,11 @@
 """SecureVibes agent definitions using proper Claude Agent SDK architecture"""
 
-from securevibes.agents.definitions import SECUREVIBES_AGENTS
+from securevibes.agents.definitions import (
+    SECUREVIBES_AGENTS,
+    create_agent_definitions
+)
 
 __all__ = [
     "SECUREVIBES_AGENTS",
+    "create_agent_definitions",
 ]

--- a/packages/core/securevibes/agents/definitions.py
+++ b/packages/core/securevibes/agents/definitions.py
@@ -1,5 +1,6 @@
 """Agent definitions"""
 
+from typing import Dict, Optional
 from claude_agent_sdk import AgentDefinition
 from securevibes.prompts.loader import load_all_agent_prompts
 from securevibes.config import config
@@ -7,32 +8,71 @@ from securevibes.config import config
 # Load all prompts from centralized prompt files
 AGENT_PROMPTS = load_all_agent_prompts()
 
-SECUREVIBES_AGENTS = {
-    "assessment": AgentDefinition(
-        description="Analyzes codebase architecture and creates comprehensive security documentation",
-        prompt=AGENT_PROMPTS["assessment"],
-        tools=["Read", "Grep", "Glob", "LS", "Write"],
-        model=config.get_agent_model("assessment")
-    ),
 
-    "threat-modeling": AgentDefinition(
-        description="Performs architecture-driven STRIDE threat modeling focused on realistic, high-impact threats",
-        prompt=AGENT_PROMPTS["threat_modeling"],
-        tools=["Read", "Grep", "Glob", "Write"],
-        model=config.get_agent_model("threat_modeling")
-    ),
+def create_agent_definitions(cli_model: Optional[str] = None) -> Dict[str, AgentDefinition]:
+    """
+    Create agent definitions with optional CLI model override.
+    
+    This function allows the CLI --model flag to cascade down to all agents
+    while still respecting per-agent environment variable overrides.
+    
+    Priority hierarchy:
+    1. Per-agent env vars (SECUREVIBES_<AGENT>_MODEL) - highest priority
+    2. cli_model parameter (from CLI --model flag) - medium priority
+    3. Default "sonnet" from config.DEFAULTS - lowest priority
+    
+    Args:
+        cli_model: Optional model name from CLI --model flag.
+                  If provided, becomes the default for all agents unless
+                  overridden by per-agent environment variables.
+    
+    Returns:
+        Dictionary mapping agent names to AgentDefinition objects
+    
+    Examples:
+        # Use CLI model as default for all agents
+        agents = create_agent_definitions(cli_model="haiku")
+        
+        # Use hardcoded defaults (sonnet)
+        agents = create_agent_definitions()
+        
+        # Per-agent env var overrides CLI model
+        os.environ['SECUREVIBES_CODE_REVIEW_MODEL'] = 'opus'
+        agents = create_agent_definitions(cli_model="haiku")
+        # Result: assessment/threat-modeling/report-generator use haiku
+        #         code-review uses opus
+    """
+    return {
+        "assessment": AgentDefinition(
+            description="Analyzes codebase architecture and creates comprehensive security documentation",
+            prompt=AGENT_PROMPTS["assessment"],
+            tools=["Read", "Grep", "Glob", "LS", "Write"],
+            model=config.get_agent_model("assessment", cli_override=cli_model)
+        ),
 
-    "code-review": AgentDefinition(
-        description="Applies security thinking methodology to find vulnerabilities with concrete evidence and exploitability analysis",
-        prompt=AGENT_PROMPTS["code_review"],
-        tools=["Read", "Grep", "Glob", "Write"],
-        model=config.get_agent_model("code_review")
-    ),
+        "threat-modeling": AgentDefinition(
+            description="Performs architecture-driven STRIDE threat modeling focused on realistic, high-impact threats",
+            prompt=AGENT_PROMPTS["threat_modeling"],
+            tools=["Read", "Grep", "Glob", "Write"],
+            model=config.get_agent_model("threat_modeling", cli_override=cli_model)
+        ),
 
-    "report-generator": AgentDefinition(
-        description="JSON file processor that reformats VULNERABILITIES.json to scan_results.json",
-        prompt=AGENT_PROMPTS["report_generator"],
-        tools=["Read", "Write"],
-        model=config.get_agent_model("report_generator")
-    )
-}
+        "code-review": AgentDefinition(
+            description="Applies security thinking methodology to find vulnerabilities with concrete evidence and exploitability analysis",
+            prompt=AGENT_PROMPTS["code_review"],
+            tools=["Read", "Grep", "Glob", "Write"],
+            model=config.get_agent_model("code_review", cli_override=cli_model)
+        ),
+
+        "report-generator": AgentDefinition(
+            description="JSON file processor that reformats VULNERABILITIES.json to scan_results.json",
+            prompt=AGENT_PROMPTS["report_generator"],
+            tools=["Read", "Write"],
+            model=config.get_agent_model("report_generator", cli_override=cli_model)
+        )
+    }
+
+
+# Backward compatibility: export default instance (no CLI override)
+# This ensures existing code that imports SECUREVIBES_AGENTS still works
+SECUREVIBES_AGENTS = create_agent_definitions()

--- a/packages/core/securevibes/scanner/scanner.py
+++ b/packages/core/securevibes/scanner/scanner.py
@@ -17,7 +17,7 @@ from claude_agent_sdk.types import (
     ResultMessage
 )
 
-from securevibes.agents.definitions import SECUREVIBES_AGENTS
+from securevibes.agents.definitions import create_agent_definitions
 from securevibes.models.result import ScanResult
 from securevibes.models.issue import SecurityIssue, Severity
 from securevibes.prompts.loader import load_prompt
@@ -287,8 +287,12 @@ class Scanner:
         # Configure agent options with hooks
         from claude_agent_sdk.types import HookMatcher
         
+        # Create agent definitions with CLI model override
+        # This allows --model flag to cascade to all agents while respecting env vars
+        agents = create_agent_definitions(cli_model=self.model)
+        
         options = ClaudeAgentOptions(
-            agents=SECUREVIBES_AGENTS,
+            agents=agents,
             cwd=str(repo),
             max_turns=config.get_max_turns(),
             permission_mode='bypassPermissions',

--- a/packages/core/tests/test_agents.py
+++ b/packages/core/tests/test_agents.py
@@ -1,0 +1,172 @@
+"""Tests for agent definitions"""
+
+import os
+import pytest
+from securevibes.agents.definitions import create_agent_definitions, SECUREVIBES_AGENTS
+
+
+class TestAgentDefinitions:
+    """Test agent definition creation"""
+    
+    def test_create_agents_without_override(self, monkeypatch):
+        """Creating agents without override uses defaults"""
+        # Clear env vars
+        for agent in ["assessment", "threat_modeling", "code_review", "report_generator"]:
+            monkeypatch.delenv(f"SECUREVIBES_{agent.upper()}_MODEL", raising=False)
+        
+        agents = create_agent_definitions()
+        
+        assert agents["assessment"].model == "sonnet"
+        assert agents["threat-modeling"].model == "sonnet"
+        assert agents["code-review"].model == "sonnet"
+        assert agents["report-generator"].model == "sonnet"
+    
+    def test_create_agents_with_cli_override(self, monkeypatch):
+        """Creating agents with CLI override sets all models"""
+        # Clear env vars
+        for agent in ["assessment", "threat_modeling", "code_review", "report_generator"]:
+            monkeypatch.delenv(f"SECUREVIBES_{agent.upper()}_MODEL", raising=False)
+        
+        agents = create_agent_definitions(cli_model="haiku")
+        
+        assert agents["assessment"].model == "haiku"
+        assert agents["threat-modeling"].model == "haiku"
+        assert agents["code-review"].model == "haiku"
+        assert agents["report-generator"].model == "haiku"
+    
+    def test_create_agents_env_var_overrides_cli(self, monkeypatch):
+        """Environment variables override CLI model"""
+        # Clear most env vars, set one override
+        monkeypatch.delenv("SECUREVIBES_ASSESSMENT_MODEL", raising=False)
+        monkeypatch.setenv("SECUREVIBES_CODE_REVIEW_MODEL", "opus")
+        monkeypatch.delenv("SECUREVIBES_THREAT_MODELING_MODEL", raising=False)
+        monkeypatch.delenv("SECUREVIBES_REPORT_GENERATOR_MODEL", raising=False)
+        
+        agents = create_agent_definitions(cli_model="haiku")
+        
+        # Most use CLI model
+        assert agents["assessment"].model == "haiku"
+        assert agents["threat-modeling"].model == "haiku"
+        assert agents["report-generator"].model == "haiku"
+        
+        # One uses env var override
+        assert agents["code-review"].model == "opus"
+    
+    def test_default_agents_dict_exists(self):
+        """Default SECUREVIBES_AGENTS dict should exist"""
+        assert SECUREVIBES_AGENTS is not None
+        assert isinstance(SECUREVIBES_AGENTS, dict)
+        assert len(SECUREVIBES_AGENTS) == 4
+    
+    def test_agent_definition_structure(self, monkeypatch):
+        """Agent definitions should have correct structure"""
+        # Clear env vars
+        for agent in ["assessment", "threat_modeling", "code_review", "report_generator"]:
+            monkeypatch.delenv(f"SECUREVIBES_{agent.upper()}_MODEL", raising=False)
+        
+        agents = create_agent_definitions(cli_model="haiku")
+        
+        # Check assessment agent
+        agent = agents["assessment"]
+        assert agent.description is not None
+        assert agent.prompt is not None
+        assert agent.tools is not None
+        assert len(agent.tools) > 0
+        assert agent.model == "haiku"
+    
+    def test_all_agents_have_required_attributes(self, monkeypatch):
+        """All agents should have description, prompt, tools, model"""
+        # Clear env vars
+        for agent in ["assessment", "threat_modeling", "code_review", "report_generator"]:
+            monkeypatch.delenv(f"SECUREVIBES_{agent.upper()}_MODEL", raising=False)
+        
+        agents = create_agent_definitions(cli_model="sonnet")
+        
+        for agent_name, agent_def in agents.items():
+            assert agent_def.description, f"{agent_name} missing description"
+            assert agent_def.prompt, f"{agent_name} missing prompt"
+            assert agent_def.tools, f"{agent_name} missing tools"
+            assert isinstance(agent_def.tools, list), f"{agent_name} tools not a list"
+            assert agent_def.model, f"{agent_name} missing model"
+    
+    def test_agents_have_expected_tools(self, monkeypatch):
+        """Agents should have appropriate tool access"""
+        # Clear env vars
+        for agent in ["assessment", "threat_modeling", "code_review", "report_generator"]:
+            monkeypatch.delenv(f"SECUREVIBES_{agent.upper()}_MODEL", raising=False)
+        
+        agents = create_agent_definitions()
+        
+        # Assessment needs LS for directory listing
+        assert "LS" in agents["assessment"].tools
+        
+        # All need Read and Write
+        for agent_name in ["assessment", "threat-modeling", "code-review", "report-generator"]:
+            assert "Read" in agents[agent_name].tools
+            assert "Write" in agents[agent_name].tools
+    
+    def test_create_agents_with_multiple_env_overrides(self, monkeypatch):
+        """Multiple environment variables should all work"""
+        monkeypatch.setenv("SECUREVIBES_ASSESSMENT_MODEL", "haiku")
+        monkeypatch.setenv("SECUREVIBES_THREAT_MODELING_MODEL", "haiku")
+        monkeypatch.setenv("SECUREVIBES_CODE_REVIEW_MODEL", "opus")
+        monkeypatch.setenv("SECUREVIBES_REPORT_GENERATOR_MODEL", "sonnet")
+        
+        agents = create_agent_definitions(cli_model="sonnet")
+        
+        # Env vars should override CLI model
+        assert agents["assessment"].model == "haiku"
+        assert agents["threat-modeling"].model == "haiku"
+        assert agents["code-review"].model == "opus"
+        assert agents["report-generator"].model == "sonnet"
+    
+    def test_backward_compatibility_default_dict(self, monkeypatch):
+        """SECUREVIBES_AGENTS should work like before (no CLI override)"""
+        # Clear env vars
+        for agent in ["assessment", "threat_modeling", "code_review", "report_generator"]:
+            monkeypatch.delenv(f"SECUREVIBES_{agent.upper()}_MODEL", raising=False)
+        
+        # Default dict should use defaults (sonnet)
+        assert SECUREVIBES_AGENTS["assessment"].model == "sonnet"
+        assert SECUREVIBES_AGENTS["threat-modeling"].model == "sonnet"
+        assert SECUREVIBES_AGENTS["code-review"].model == "sonnet"
+        assert SECUREVIBES_AGENTS["report-generator"].model == "sonnet"
+
+
+class TestAgentCreationEdgeCases:
+    """Test edge cases in agent creation"""
+    
+    def test_create_with_empty_string_cli_model(self, monkeypatch):
+        """Empty string CLI model should fall back to defaults"""
+        # Clear env vars
+        for agent in ["assessment", "threat_modeling", "code_review", "report_generator"]:
+            monkeypatch.delenv(f"SECUREVIBES_{agent.upper()}_MODEL", raising=False)
+        
+        agents = create_agent_definitions(cli_model="")
+        
+        # Should use defaults
+        assert agents["assessment"].model == "sonnet"
+        assert agents["threat-modeling"].model == "sonnet"
+    
+    def test_create_with_none_cli_model(self, monkeypatch):
+        """None CLI model should fall back to defaults"""
+        # Clear env vars
+        for agent in ["assessment", "threat_modeling", "code_review", "report_generator"]:
+            monkeypatch.delenv(f"SECUREVIBES_{agent.upper()}_MODEL", raising=False)
+        
+        agents = create_agent_definitions(cli_model=None)
+        
+        # Should use defaults
+        assert agents["assessment"].model == "sonnet"
+        assert agents["threat-modeling"].model == "sonnet"
+    
+    def test_agent_names_consistency(self):
+        """Agent names should be consistent across calls"""
+        agents1 = create_agent_definitions()
+        agents2 = create_agent_definitions()
+        
+        assert set(agents1.keys()) == set(agents2.keys())
+        assert "assessment" in agents1
+        assert "threat-modeling" in agents1
+        assert "code-review" in agents1
+        assert "report-generator" in agents1


### PR DESCRIPTION
## 🎯 Overview

This PR implements a flexible three-tier model selection system that allows users to control which Claude models are used for each agent, with a clear priority hierarchy.

## 🚀 Features

### Three-Tier Priority System

1. **Per-Agent Environment Variables** (Highest Priority)
   - `SECUREVIBES_ASSESSMENT_MODEL`
   - `SECUREVIBES_THREAT_MODELING_MODEL`
   - `SECUREVIBES_CODE_REVIEW_MODEL`
   - `SECUREVIBES_REPORT_GENERATOR_MODEL`

2. **CLI `--model` Flag** (Medium Priority)
   - Applies to all agents unless overridden by env vars
   - Example: `securevibes scan . --model haiku`

3. **Default "sonnet"** (Lowest Priority)
   - Falls back when no CLI or env var is set

## 📋 Implementation Details

### Core Changes

**1. `config.py`**
- Added `cli_override: Optional[str]` parameter to `get_agent_model()`
- Implemented three-tier priority logic with clear precedence rules
- Enhanced docstring with examples

**2. `definitions.py`**
- Created `create_agent_definitions(cli_model)` factory function
- Allows dynamic agent creation with CLI model override
- Maintains backward compatibility via module-level `SECUREVIBES_AGENTS`

**3. `scanner.py`**
- Modified to call `create_agent_definitions(cli_model=self.model)`
- CLI model now cascades to all agents
- Added comments explaining the cascade behavior

**4. `agents/__init__.py`**
- Exports both `SECUREVIBES_AGENTS` (backward compat) and `create_agent_definitions` (new API)

### Test Coverage

**New Tests Added: 19 total**

**`test_config.py` - 7 new tests:**
- `test_cli_override_takes_precedence_over_default`
- `test_env_var_takes_precedence_over_cli_override`
- `test_cli_override_none_uses_default`
- `test_three_tier_hierarchy`
- `test_cli_override_with_all_agents`
- `test_empty_string_cli_override_uses_default`
- `test_mixed_cli_and_env_vars`

**`test_agents.py` - 12 new tests (new file):**
- Agent creation with/without CLI override
- Environment variable override behavior
- Backward compatibility verification
- Edge cases (empty string, None, etc.)
- Agent structure validation

**Test Results:**
```
========================= 41 passed, 1 warning in 0.15s =========================
```

## 💡 Usage Examples

### Example 1: Global Model Override
```bash
# All agents use haiku
securevibes scan . --model haiku
```

### Example 2: Mix CLI and Environment Variables
```bash
# Use opus for code review, haiku for everything else
export SECUREVIBES_CODE_REVIEW_MODEL=opus
securevibes scan . --model haiku
```

### Example 3: Fine-Grained Control
```bash
# Different models for different agents
export SECUREVIBES_ASSESSMENT_MODEL=haiku        # Fast
export SECUREVIBES_THREAT_MODELING_MODEL=haiku   # Fast
export SECUREVIBES_CODE_REVIEW_MODEL=opus        # Most powerful
export SECUREVIBES_REPORT_GENERATOR_MODEL=sonnet # Balanced
securevibes scan .
```

### Example 4: Use Defaults
```bash
# All agents use default (sonnet)
securevibes scan .
```

## 🔄 Backward Compatibility

✅ **Fully backward compatible** - No breaking changes

- Existing code importing `SECUREVIBES_AGENTS` continues to work
- Adding `cli_override` parameter with default `None` maintains existing behavior
- Module-level agent dict still available for scripts/tools

## 🎓 Why This Design?

### Problem Solved
Previously, the `--model` CLI flag only affected the orchestrator model, not sub-agents. Each agent used hardcoded defaults, making it impossible to:
- Run cost-effective scans with cheaper models
- Use more powerful models for specific phases
- Test different model configurations

### Solution Benefits
1. **Intuitive UX**: `--model haiku` affects everything as users expect
2. **Fine-grained control**: Per-agent env vars for power users
3. **Clean architecture**: No global state, pure functions
4. **Well-tested**: 19 new tests covering all scenarios
5. **Backward compatible**: Existing code unaffected

## 📊 Impact Summary

| Metric | Before | After |
|--------|--------|-------|
| Model configuration layers | 1 (env vars only) | 3 (env vars > CLI > default) |
| CLI model applies to | Orchestrator only | All agents |
| Test coverage | Config tests only | Config + Agent definition tests |
| Lines changed | N/A | +355, -36 (net +319) |
| Tests added | 0 | 19 |
| Breaking changes | N/A | 0 |

## ✅ Checklist

- [x] Implementation complete
- [x] Tests added and passing (41 tests, 100% pass rate)
- [x] Backward compatibility maintained
- [x] Documentation in code (docstrings, examples)
- [x] No breaking changes
- [x] Clean git history

## 🔗 Related Issues

Fixes the issue where `--model haiku` flag was being ignored by sub-agents, causing unexpected costs and behavior.

---

**Ready to merge** after review.