### PR TITLE
fix: DAST agent ignores --target-url, infers incorrect URL from project directory

### DIFF
--- a/packages/core/securevibes/scanner/scanner.py
+++ b/packages/core/securevibes/scanner/scanner.py
@@ -602,9 +602,11 @@ class Scanner:
         # Configure agent options with hooks
         from claude_agent_sdk.types import HookMatcher
         
-        # Create agent definitions with CLI model override
+        # Create agent definitions with CLI model override and DAST target URL
         # This allows --model flag to cascade to all agents while respecting env vars
-        agents = create_agent_definitions(cli_model=self.model)
+        # The DAST target URL is passed to substitute {target_url} placeholders in the prompt
+        dast_url = self.dast_config.get("target_url") if self.dast_enabled else None
+        agents = create_agent_definitions(cli_model=self.model, dast_target_url=dast_url)
 
         # Skills configuration:
         # - Skills must be explicitly enabled via setting_sources=["project"]

--- a/packages/core/tests/test_dast.py
+++ b/packages/core/tests/test_dast.py
@@ -295,6 +295,66 @@ class TestScannerDASTConfiguration:
         assert scanner.dast_config["accounts_path"] is None
 
 
+class TestDASTPromptTargetURLSubstitution:
+    """Test that target URL is correctly substituted in DAST prompt"""
+    
+    def test_target_url_substituted_in_prompt(self):
+        """Test that {target_url} placeholder is replaced with actual URL"""
+        from securevibes.agents.definitions import create_agent_definitions
+        
+        target_url = "http://localhost:3000"
+        agents = create_agent_definitions(dast_target_url=target_url)
+        
+        dast_prompt = agents["dast"].prompt
+        
+        # Verify the target URL is in the prompt
+        assert target_url in dast_prompt
+        # Verify the placeholder is NOT in the prompt
+        assert "{target_url}" not in dast_prompt
+        # Verify specific substituted lines
+        assert f"Target application is running at: {target_url}" in dast_prompt
+        assert f"ONLY test {target_url}" in dast_prompt
+    
+    def test_target_url_not_substituted_when_none(self):
+        """Test that {target_url} placeholder remains when no URL provided"""
+        from securevibes.agents.definitions import create_agent_definitions
+        
+        agents = create_agent_definitions(dast_target_url=None)
+        
+        dast_prompt = agents["dast"].prompt
+        
+        # Verify the placeholder is still in the prompt
+        assert "{target_url}" in dast_prompt
+    
+    def test_custom_target_url_substitution(self):
+        """Test custom target URL is correctly substituted"""
+        from securevibes.agents.definitions import create_agent_definitions
+        
+        custom_url = "http://aerocity-staging.bpbatam.go.id"
+        agents = create_agent_definitions(dast_target_url=custom_url)
+        
+        dast_prompt = agents["dast"].prompt
+        
+        # Verify custom URL is in the prompt
+        assert custom_url in dast_prompt
+        assert "{target_url}" not in dast_prompt
+        assert f"Target application is running at: {custom_url}" in dast_prompt
+        assert f"ONLY test {custom_url}" in dast_prompt
+    
+    def test_target_url_combined_with_model_override(self):
+        """Test target URL substitution works with model override"""
+        from securevibes.agents.definitions import create_agent_definitions
+        
+        target_url = "http://localhost:8080"
+        agents = create_agent_definitions(cli_model="haiku", dast_target_url=target_url)
+        
+        dast_prompt = agents["dast"].prompt
+        
+        # Verify URL substitution
+        assert target_url in dast_prompt
+        assert "{target_url}" not in dast_prompt
+
+
 class TestValidationStatus:
     """Test ValidationStatus enum and issue models"""
     


### PR DESCRIPTION
## Problem

When running the DAST sub-agent with a custom `--target-url`, the agent ignores the provided URL and instead infers an incorrect one based on the project directory name.

**Example command:**
```bash
securevibes scan . --subagent dast --target-url http://my-staging-server.example.com --dast-accounts test_accounts.json
```

**Expected:** DAST agent tests `http://my-staging-server.example.com`
**Actual:** DAST agent tests `http://localhost/project-folder-name` (incorrectly inferred)

## Root Cause

The DAST prompt in `prompts/agents/dast.txt` contains `{target_url}` placeholders (lines 7 and 44) that were never substituted with the actual URL. The prompt was loaded as raw text, so the AI agent saw literal `{target_url}` and had to guess the URL.

## Solution

1. **`agents/definitions.py`**: Added `dast_target_url` parameter to `create_agent_definitions()` that substitutes `{target_url}` placeholders using `str.replace()`

2. **`scanner/scanner.py`**: Pass the DAST target URL from `dast_config` when creating agent definitions

3. **`tests/test_dast.py`**: Added 4 new tests (`TestDASTPromptTargetURLSubstitution`) to verify URL substitution

## Testing

All 41 DAST tests pass:
```
=================== 41 passed, 3 skipped in 0.51s ===================
```

## Files Changed

- `packages/core/securevibes/agents/definitions.py`
- `packages/core/securevibes/scanner/scanner.py`
- `packages/core/tests/test_dast.py`