### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # 🛡️ SecureVibes
 
+[![Run in Smithery](https://smithery.ai/badge/skills/anshumanbh)](https://smithery.ai/skills?ns=anshumanbh&utm_source=github&utm_medium=badge)
+
+
 **AI-Native Security System for Vibecoded Applications**
 
 SecureVibes uses **Claude's multi-agent architecture** to autonomously find security vulnerabilities in your codebase. Five specialized AI agents (4 required + 1 optional DAST) work together to deliver comprehensive, context-aware security analysis with concrete evidence.


### PR DESCRIPTION
## Add skill discoverability badge

Your 1 Claude skill is already indexed on [Smithery](https://smithery.ai), a directory of Claude Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/anshumanbh)](https://smithery.ai/skills?ns=anshumanbh&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.