### PR TITLE
fix(scanner): add missing description field to code review required fields list

### DIFF
--- a/packages/core/securevibes/prompts/agents/code_review.txt
+++ b/packages/core/securevibes/prompts/agents/code_review.txt
@@ -189,7 +189,7 @@ CRITICAL OUTPUT REQUIREMENTS:
 1. Format: Flat JSON array starting with [ and ending with ]
 2. NO wrapper objects like {"vulnerabilities": [...]}
 3. NO summary sections
-4. Each vulnerability must have all required fields (threat_id, title, severity, file_path, line_number, code_snippet, cwe_id, recommendation, evidence)
+4. Each vulnerability must have all required fields (threat_id, title, description, severity, file_path, line_number, code_snippet, cwe_id, recommendation, evidence)
 5. Use lowercase for severity: "critical", "high", "medium", "low", "info".
 6. If no vulnerabilities found, write: []
 


### PR DESCRIPTION
## Summary
- Fixed validation error where VULNERABILITIES.json items were missing the required `description` field
- Updated code review agent prompt to explicitly include `description` in the required fields list

## Root Cause
The code review agent was generating vulnerability objects without the `description` field because line 192 of the CRITICAL OUTPUT REQUIREMENTS section omitted it from the required fields list, even though it's a mandatory field in the Pydantic schema.

## Changes
- Added `description` to the required fields list in `packages/core/securevibes/prompts/agents/code_review.txt:192`

## Testing
Verified that after this fix:
- ✅ VULNERABILITIES.json schema validated successfully
- ✅ No more "missing required fields: {'description'}" errors
- ✅ Scan completes without Pydantic validation failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)