### PR TITLE
fix(schemas): align vulnerability required fields

### DIFF
--- a/packages/core/securevibes/models/schemas.py
+++ b/packages/core/securevibes/models/schemas.py
@@ -63,7 +63,18 @@ VULNERABILITY_SCHEMA: Dict[str, Any] = {
             "description": "Proof this is exploitable",
         },
     },
-    "required": ["threat_id", "title", "description", "severity"],
+    "required": [
+        "threat_id",
+        "title",
+        "description",
+        "severity",
+        "file_path",
+        "line_number",
+        "code_snippet",
+        "cwe_id",
+        "recommendation",
+        "evidence",
+    ],
     "additionalProperties": False,
 }
 
@@ -322,7 +333,7 @@ def validate_vulnerabilities_json(content: str) -> Tuple[bool, Optional[str]]:
         return False, "Output must be a JSON array"
 
     # Validate each vulnerability
-    required_fields = {"threat_id", "title", "description", "severity"}
+    required_fields = set(VULNERABILITY_SCHEMA["required"])
     valid_severities = {"critical", "high", "medium", "low", "info"}
 
     for i, vuln in enumerate(data):

--- a/packages/core/securevibes/prompts/agents/code_review.txt
+++ b/packages/core/securevibes/prompts/agents/code_review.txt
@@ -160,7 +160,7 @@ CRITICAL OUTPUT REQUIREMENTS:
 1. Format: Flat JSON array starting with [ and ending with ]
 2. NO wrapper objects like {"vulnerabilities": [...]}
 3. NO summary sections
-4. Each vulnerability must have all required fields (threat_id, title, severity, file_path, line_number, code_snippet, cwe_id, recommendation, evidence)
+4. Each vulnerability must have all required fields (threat_id, title, description, severity, file_path, line_number, code_snippet, cwe_id, recommendation, evidence)
 5. Use lowercase for severity: "critical", "high", "medium", "low", "info".
 6. If no vulnerabilities found, write: []
 

--- a/packages/core/tests/test_hooks.py
+++ b/packages/core/tests/test_hooks.py
@@ -424,6 +424,12 @@ class TestJsonValidationHook:
             "title": "SQL Injection",
             "description": "Test vulnerability",
             "severity": "high",
+            "file_path": "app.py",
+            "line_number": 42,
+            "code_snippet": "cursor.execute(query)",
+            "cwe_id": "CWE-89",
+            "recommendation": "Use parameterized queries",
+            "evidence": "User input concatenated into SQL query",
         }
 
     @pytest.mark.asyncio

--- a/packages/core/tests/test_scan_output.py
+++ b/packages/core/tests/test_scan_output.py
@@ -381,6 +381,12 @@ class TestScanOutputSchemaHelpers:
         assert "title" in required
         assert "description" in required
         assert "severity" in required
+        assert "file_path" in required
+        assert "line_number" in required
+        assert "code_snippet" in required
+        assert "cwe_id" in required
+        assert "recommendation" in required
+        assert "evidence" in required
 
     def test_get_json_schema_severity_enum(self):
         """Test severity property has enum constraint"""

--- a/packages/core/tests/test_schemas.py
+++ b/packages/core/tests/test_schemas.py
@@ -162,6 +162,12 @@ class TestValidateVulnerabilitiesJson:
             "title": "SQL Injection",
             "description": "Test vulnerability",
             "severity": "high",
+            "file_path": "app.py",
+            "line_number": 42,
+            "code_snippet": "cursor.execute(query)",
+            "cwe_id": "CWE-89",
+            "recommendation": "Use parameterized queries",
+            "evidence": "User input concatenated into SQL query",
         }
 
     def test_valid_flat_array(self):
@@ -223,6 +229,72 @@ class TestValidateVulnerabilitiesJson:
 
         assert is_valid is False
         assert "severity" in error
+
+    def test_missing_file_path(self):
+        """Missing file_path should fail validation."""
+        vuln = self._make_valid_vuln()
+        del vuln["file_path"]
+        content = json.dumps([vuln])
+
+        is_valid, error = validate_vulnerabilities_json(content)
+
+        assert is_valid is False
+        assert "file_path" in error
+
+    def test_missing_line_number(self):
+        """Missing line_number should fail validation."""
+        vuln = self._make_valid_vuln()
+        del vuln["line_number"]
+        content = json.dumps([vuln])
+
+        is_valid, error = validate_vulnerabilities_json(content)
+
+        assert is_valid is False
+        assert "line_number" in error
+
+    def test_missing_code_snippet(self):
+        """Missing code_snippet should fail validation."""
+        vuln = self._make_valid_vuln()
+        del vuln["code_snippet"]
+        content = json.dumps([vuln])
+
+        is_valid, error = validate_vulnerabilities_json(content)
+
+        assert is_valid is False
+        assert "code_snippet" in error
+
+    def test_missing_cwe_id(self):
+        """Missing cwe_id should fail validation."""
+        vuln = self._make_valid_vuln()
+        del vuln["cwe_id"]
+        content = json.dumps([vuln])
+
+        is_valid, error = validate_vulnerabilities_json(content)
+
+        assert is_valid is False
+        assert "cwe_id" in error
+
+    def test_missing_recommendation(self):
+        """Missing recommendation should fail validation."""
+        vuln = self._make_valid_vuln()
+        del vuln["recommendation"]
+        content = json.dumps([vuln])
+
+        is_valid, error = validate_vulnerabilities_json(content)
+
+        assert is_valid is False
+        assert "recommendation" in error
+
+    def test_missing_evidence(self):
+        """Missing evidence should fail validation."""
+        vuln = self._make_valid_vuln()
+        del vuln["evidence"]
+        content = json.dumps([vuln])
+
+        is_valid, error = validate_vulnerabilities_json(content)
+
+        assert is_valid is False
+        assert "evidence" in error
 
     def test_invalid_severity_value(self):
         """Invalid severity value should fail validation."""
@@ -323,6 +395,12 @@ class TestSchemaStructure:
         assert "title" in required
         assert "description" in required
         assert "severity" in required
+        assert "file_path" in required
+        assert "line_number" in required
+        assert "code_snippet" in required
+        assert "cwe_id" in required
+        assert "recommendation" in required
+        assert "evidence" in required
 
     def test_vulnerability_schema_severity_enum(self):
         """Severity should have correct enum values."""


### PR DESCRIPTION
## Summary
- Align vulnerability schema/validator required fields with the code-review prompt
- Extend schema-related tests and hook fixtures for the full required field set

## Testing
- black packages/core/securevibes packages/core/tests
- ruff check packages/core/securevibes packages/core/tests
- pytest packages/core/tests/
- PYTHONPATH=packages/core python3 -c "import securevibes; print('OK')"