### PR TITLE
fix: Windows compatibility for UTF-8 output and Rich console

### DIFF
--- a/packages/core/securevibes/cli/main.py
+++ b/packages/core/securevibes/cli/main.py
@@ -1,6 +1,7 @@
 """Main CLI entry point for SecureVibes"""
 
 import asyncio
+import io
 import sys
 from pathlib import Path
 from typing import Optional
@@ -20,7 +21,12 @@ from securevibes.diff.extractor import (
 )
 from securevibes.diff.parser import DiffContext, parse_unified_diff
 
-console = Console()
+# Ensure UTF-8 output on Windows to handle emojis and special characters
+if sys.platform == "win32" and not isinstance(sys.stdout, io.TextIOWrapper):
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8', errors='replace')
+    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8', errors='replace')
+
+console = Console(force_terminal=True)
 
 
 @click.group()

--- a/packages/core/securevibes/scanner/subagent_manager.py
+++ b/packages/core/securevibes/scanner/subagent_manager.py
@@ -1,6 +1,8 @@
 """Sub-agent execution manager with artifact detection and dependency resolution"""
 
+import io
 import json
+import sys
 from pathlib import Path
 from typing import Dict, Optional, List, Tuple
 from dataclasses import dataclass
@@ -11,7 +13,12 @@ import click
 from rich.console import Console
 from rich.table import Table
 
-console = Console()
+# Ensure UTF-8 output on Windows to handle emojis and special characters
+if sys.platform == "win32" and not isinstance(sys.stdout, io.TextIOWrapper):
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8', errors='replace')
+    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8', errors='replace')
+
+console = Console(force_terminal=True)
 
 
 class ScanMode(Enum):

--- a/packages/core/tests/test_scan_output.py
+++ b/packages/core/tests/test_scan_output.py
@@ -209,6 +209,22 @@ class TestVulnerability:
         assert isinstance(vuln.evidence, dict)
         assert vuln.evidence["request"] == "GET /admin"
 
+    def test_evidence_list(self):
+        """Test evidence can be a list of dicts (multi-file evidence)"""
+        vuln = Vulnerability(
+            threat_id="T-001",
+            title="Test",
+            description="Test desc",
+            severity="high",
+            evidence=[
+                {"file": "src/db.py", "finding": "unencrypted database"},
+                {"file": "src/config.py", "finding": "hardcoded credentials"}
+            ]
+        )
+        assert isinstance(vuln.evidence, list)
+        assert len(vuln.evidence) == 2
+        assert vuln.evidence[0]["file"] == "src/db.py"
+
 
 class TestScanOutput:
     """Test ScanOutput model and validate_input"""


### PR DESCRIPTION
## Summary
- Add UTF-8 stream wrappers (`io.TextIOWrapper`) for `sys.stdout`/`sys.stderr` on Windows to handle emojis and special characters in scan output
- Use `Console(force_terminal=True)` for Rich console instances to ensure correct rendering on Windows terminals
- Always regenerate scan artifacts (not just when DAST is enabled), fixing `securevibes report` output on all platforms
- Add test for list-of-dicts evidence format

## Files changed
- `packages/core/securevibes/cli/main.py` — UTF-8 wrapper + force_terminal
- `packages/core/securevibes/scanner/scanner.py` — UTF-8 wrapper + force_terminal + always regenerate artifacts + conditional debug message
- `packages/core/securevibes/scanner/subagent_manager.py` — UTF-8 wrapper + force_terminal
- `packages/core/tests/test_scan_output.py` — Test for evidence as list of dicts

## Test plan
- [ ] Run `securevibes scan` on Windows and verify emoji/special characters render correctly
- [ ] Run `securevibes report` after a scan and verify artifacts are generated
- [ ] Run existing test suite: `pytest packages/core/tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)