### PR TITLE
feat: add pr-review retry tuning + early exit on clean diffs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ settings.local.json
 triage-progress.json
 
 youtube-scripts/
+packages/core/uv.lock

--- a/ops/tests/test_incremental_scan.py
+++ b/ops/tests/test_incremental_scan.py
@@ -448,6 +448,7 @@ def test_small_window_single_scan(
         debug: bool,
         output_path: Path,
         timeout_seconds: int,
+        **_kwargs: Any,
     ) -> inc.ScanCommandResult:
         calls.append((base, head))
         return _valid_result(["securevibes"], output_path)
@@ -492,6 +493,7 @@ def test_medium_window_chunked_scans(
         debug: bool,
         output_path: Path,
         timeout_seconds: int,
+        **_kwargs: Any,
     ) -> inc.ScanCommandResult:
         calls.append((base, head))
         return _valid_result(["securevibes"], output_path)
@@ -535,6 +537,7 @@ def test_large_window_per_commit_scans(
         debug: bool,
         output_path: Path,
         timeout_seconds: int,
+        **_kwargs: Any,
     ) -> inc.ScanCommandResult:
         calls.append((base, head))
         return _valid_result(["securevibes"], output_path)
@@ -580,6 +583,7 @@ def test_partial_failure_anchors_at_last_success(
         debug: bool,
         output_path: Path,
         timeout_seconds: int,
+        **_kwargs: Any,
     ) -> inc.ScanCommandResult:
         call_count["n"] += 1
         if call_count["n"] == 1:
@@ -677,6 +681,7 @@ def test_since_date_policy_success(
         debug: bool,
         output_path: Path,
         timeout_seconds: int,
+        **_kwargs: Any,
     ) -> inc.ScanCommandResult:
         return _valid_result(["securevibes"], output_path)
 
@@ -715,6 +720,7 @@ def test_since_date_policy_strict_returns_nonzero(
         debug: bool,
         output_path: Path,
         timeout_seconds: int,
+        **_kwargs: Any,
     ) -> inc.ScanCommandResult:
         return _valid_result(["securevibes"], output_path)
 
@@ -779,6 +785,7 @@ def test_findings_exit_codes_advance_anchor(
         debug: bool,
         output_path: Path,
         timeout_seconds: int,
+        **_kwargs: Any,
     ) -> inc.ScanCommandResult:
         return _valid_result(["securevibes"], output_path, exit_code=1)
 
@@ -819,6 +826,7 @@ def test_exit_1_without_output_halts_pipeline(
         debug: bool,
         output_path: Path,
         timeout_seconds: int,
+        **_kwargs: Any,
     ) -> inc.ScanCommandResult:
         return inc.ScanCommandResult(
             command=["securevibes"],
@@ -864,6 +872,7 @@ def test_run_record_written_with_chunk_results(
         debug: bool,
         output_path: Path,
         timeout_seconds: int,
+        **_kwargs: Any,
     ) -> inc.ScanCommandResult:
         return _valid_result(["securevibes", "pr-review"], output_path)
 

--- a/packages/core/securevibes/cli/main.py
+++ b/packages/core/securevibes/cli/main.py
@@ -479,6 +479,18 @@ def scan(
     default="medium",
     help="Minimum severity to report",
 )
+@click.option(
+    "--pr-attempts",
+    type=click.IntRange(min=1),
+    default=None,
+    help="Number of PR review retry attempts (default: from config/env)",
+)
+@click.option(
+    "--pr-timeout",
+    type=click.IntRange(min=1),
+    default=None,
+    help="Per-attempt timeout in seconds (default: from config/env)",
+)
 def pr_review(
     path: str,
     base: Optional[str],
@@ -495,6 +507,8 @@ def pr_review(
     output: Optional[str],
     debug: bool,
     severity: str,
+    pr_attempts: Optional[int],
+    pr_timeout: Optional[int],
 ):
     """
     Review a PR diff for security vulnerabilities.
@@ -624,6 +638,8 @@ def pr_review(
                 known_vulns,
                 severity,
                 update_artifacts,
+                pr_review_attempts=pr_attempts,
+                pr_timeout_seconds=pr_timeout,
             )
         )
 
@@ -968,6 +984,8 @@ async def _run_pr_review(
     known_vulns_path: Optional[Path],
     severity_threshold: str,
     update_artifacts: bool,
+    pr_review_attempts: Optional[int] = None,
+    pr_timeout_seconds: Optional[int] = None,
 ):
     """Run the PR review with the configured scanner."""
     scanner = Scanner(model=model, debug=debug)
@@ -977,6 +995,8 @@ async def _run_pr_review(
         known_vulns_path,
         severity_threshold,
         update_artifacts=update_artifacts,
+        pr_review_attempts=pr_review_attempts,
+        pr_timeout_seconds=pr_timeout_seconds,
     )
 
 


### PR DESCRIPTION
## Summary

Fixes #40 — incremental scan retry loop burns excessive time and money on clean diffs.

## Problem

When running `securevibes pr-review` on diffs with no security findings, the scanner always runs 4 retry attempts (up to 960s worst case). Observed on the OpenClaw repo: **835 seconds and $4.27 for a single chunk with 0 findings**.

This makes cron-driven incremental scanning unreliable on well-maintained codebases — every chunk times out even when the code is clean.

## Changes

### 1. CLI flags for `pr-review` (`cli/main.py`)
- Added `--pr-attempts` (number of retry attempts)
- Added `--pr-timeout` (per-attempt timeout in seconds)
- Both default to config/env values when not specified

### 2. Scanner threading (`scanner/scanner.py`)
- `pr_review()` and `_prepare_pr_review_context()` accept optional overrides
- When provided, they take precedence over config defaults

### 3. Incremental scanner (`ops/incremental_scan.py`)
- Added `--pr-attempts` and `--pr-timeout` argparse arguments
- Passed through as CLI flags to `securevibes pr-review` subprocess

### 4. Early exit on clean consensus (`scanner/pr_review_flow.py`)
- Tracks `consecutive_clean_passes` counter
- After 2 consecutive clean passes with zero findings (no errors, no ephemeral captures, no cumulative findings), exits early
- Counter resets on any error, warning, or finding
- **Does not affect behavior when findings ARE present** — full retry/consensus loop runs as before

## Testing

- 1347 tests pass (1 pre-existing unrelated failure in `test_scan_rejects_securevibes_symlink_escape`)
- Updated test mocks in `ops/tests/test_incremental_scan.py` to accept new kwargs

## Expected Impact

For clean diffs: ~2 attempts instead of 4 → **50%+ reduction in time and cost**
For diffs with findings: no change in behavior