### PR TITLE
fix: move scan state locks outside repos

### DIFF
--- a/packages/core/securevibes/scanner/state.py
+++ b/packages/core/securevibes/scanner/state.py
@@ -6,6 +6,7 @@ import json
 import os
 import subprocess
 import tempfile
+import hashlib
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
@@ -41,7 +42,7 @@ def update_scan_state(
 ) -> Dict[str, object]:
     """Atomically update scan state with optional full-scan/PR-review entries."""
     state_path.parent.mkdir(parents=True, exist_ok=True)
-    lock_path = state_path.with_name(f".{state_path.name}.lock")
+    lock_path = _lock_path_for_state(state_path)
     with _file_lock(lock_path):
         state = load_scan_state(state_path) or {}
 
@@ -129,6 +130,12 @@ def utc_timestamp() -> str:
     """Return current UTC timestamp in ISO format."""
     timestamp = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
     return timestamp.replace("+00:00", "Z")
+
+
+def _lock_path_for_state(state_path: Path) -> Path:
+    """Return a stable tempdir lock path for a scan-state file."""
+    digest = hashlib.sha256(str(state_path.resolve(strict=False)).encode("utf-8")).hexdigest()[:16]
+    return Path(tempfile.gettempdir()) / f"securevibes-scan-state-{digest}.lock"
 
 
 def _write_json_atomic(path: Path, payload: Mapping[str, object]) -> None:

--- a/packages/core/tests/test_scan_state.py
+++ b/packages/core/tests/test_scan_state.py
@@ -45,6 +45,19 @@ def test_update_scan_state_writes_full_scan(tmp_path: Path):
     assert persisted["last_full_scan"]["commit"] == "abc123"
 
 
+def test_update_scan_state_does_not_leave_repo_lock_file(tmp_path: Path):
+    state_path = tmp_path / "scan_state.json"
+    full_scan = build_full_scan_entry(
+        commit="abc123",
+        branch="main",
+        timestamp="2026-02-02T10:00:00Z",
+    )
+
+    update_scan_state(state_path, full_scan=full_scan)
+
+    assert not state_path.with_name(".scan_state.json.lock").exists()
+
+
 def test_update_scan_state_merges_pr_review(tmp_path: Path):
     state_path = tmp_path / "scan_state.json"
     full_scan = build_full_scan_entry(


### PR DESCRIPTION
## Summary
- move scan-state lock files out of the repo and into the system temp directory
- derive a stable temp lock path from the state file path
- add regression coverage to ensure scan state updates do not leave repo-local lock files behind

## Verification
- /Users/anshumanbhartiya/repos/securevibes/env/bin/black packages/core/securevibes/scanner/state.py packages/core/tests/test_scan_state.py
- /Users/anshumanbhartiya/repos/securevibes/env/bin/ruff check packages/core/securevibes/scanner/state.py packages/core/tests/test_scan_state.py
- /Users/anshumanbhartiya/repos/securevibes/env/bin/python -m pytest packages/core/tests/test_scan_state.py
- /Users/anshumanbhartiya/repos/securevibes/env/bin/python -m pytest packages/core/tests/
- /Users/anshumanbhartiya/repos/securevibes/env/bin/python -c "import securevibes; print('OK')"